### PR TITLE
fix: add correct handling if input line is longer than 512bytes

### DIFF
--- a/src/Channel/Channel.cpp
+++ b/src/Channel/Channel.cpp
@@ -238,3 +238,18 @@ void Channel::print_channel_info() {
   };
   std::cout << std::endl;
 }
+
+/**
+ * @brief function to check if a specific nickname is member
+ * of this channel
+ *
+ * @return returns 1 if nick was found, otherwise 0
+ */
+bool Channel::is_member(std::string nick) {
+  for (std::map<Client*, bool>::iterator client_it = _members.begin();
+       client_it != _members.end(); client_it++) {
+    if (client_it->first->get_nick() == nick)
+      return (true);
+  }
+  return (0);
+}

--- a/src/Channel/Channel.hpp
+++ b/src/Channel/Channel.hpp
@@ -2,7 +2,7 @@
 #define CHANNEL_HPP
 
 #include <ctime>  // for time-related functions
-#include <iostream>
+#include <string>
 #include <list>
 #include <map>
 #include <string>

--- a/src/Channel/Channel.hpp
+++ b/src/Channel/Channel.hpp
@@ -2,7 +2,6 @@
 #define CHANNEL_HPP
 
 #include <ctime>  // for time-related functions
-#include <string>
 #include <list>
 #include <map>
 #include <string>
@@ -85,6 +84,7 @@ class Channel {
 
   // Helpers
   void print_channel_info();
+  bool is_member(std::string nick);
 };
 
 #endif

--- a/src/Client/Client.cpp
+++ b/src/Client/Client.cpp
@@ -105,6 +105,10 @@ bool Client::get_opertr() {
   return (this->_opertr);
 }
 
+std::map<std::string, bool> &Client::get_channels(){
+	return(_channel_inscriptions);
+}
+
 void Client::set_register_status(unsigned char to_add) {
   _registered |= to_add;
 }

--- a/src/Client/Client.hpp
+++ b/src/Client/Client.hpp
@@ -20,7 +20,7 @@ class Client {
   std::string _servername;
   std::string _realname;
   std::string _output_buffer;
-  std::map<std::string, bool> channel_inscriptions;
+  std::map<std::string, bool> _channel_inscriptions;
 
  public:
   Client();
@@ -48,6 +48,7 @@ class Client {
   std::string& get_realname();
   bool get_opertr();
   unsigned char get_register_status();
+  std::map<std::string, bool>& get_channels();
   void set_register_status(unsigned char to_add);
   void set_nick(std::string nick);
   void set_user(std::string user);

--- a/src/IrcCommands/Commands/Kill.cpp
+++ b/src/IrcCommands/Commands/Kill.cpp
@@ -11,7 +11,7 @@
  * 
  * the operator cannot KILL itself
  *
- * @return 0, in case of an error it returns error codes:
+ * @return 0 if succesful, in case of an error it returns error codes:
  * ERR_NOPRIVILEGES
  * ERR_NEEDMOREPARAMS
  * ERR_NOSUCHNICK

--- a/src/IrcCommands/Commands/Kill.cpp
+++ b/src/IrcCommands/Commands/Kill.cpp
@@ -8,6 +8,10 @@
 /**
  * @brief function to kill a user (client) from server,
  * privilege of an operator
+ *
+ * TODO:
+ * send a QUIT message to the recipient and all his friends
+ * (clients the user is connected through via a channel)
  * 
  * the operator cannot KILL itself
  *
@@ -37,7 +41,20 @@ int IrcCommands::kill(Server& base, const struct cmd_obj& cmd) {
 
   if (it_client->get_nick() == cmd.client->get_nick())
     return (0);
-
+  //to be coded
+  std::list<Client*> recipients;
+  if (base._irc_commands->get_all_recipients(recipients, base, cmd.client)) {
+    std::string out;
+    for (std::list<Client*>::iterator it_rec = recipients.begin();
+         it_rec != recipients.end(); it_rec++) {
+      //send a QUIT-message (has to be created)
+      if (!out.empty()) {
+        (*it_rec)->add_client_out(out);
+        base.set_pollevent((*it_rec)->get_client_fd(), POLLOUT);
+      }
+    }
+  }
+  //
   base.remove_client(it_client->get_client_fd());
   return (0);
 }

--- a/src/IrcCommands/Commands/Nick.cpp
+++ b/src/IrcCommands/Commands/Nick.cpp
@@ -24,7 +24,7 @@ static void change_nick_msgs(IrcCommands cmd_obj, Server& base, Client* _client,
   _client->add_client_out(out);
   base.set_pollevent(_client->get_client_fd(), POLLOUT);
   std::list<Client*> recipients;
-  // calculate in a sperate function to also enable the use for KILL function
+  // calculate in a seperate function to also enable the use for KILL function
   if (cmd_obj.get_all_recipients(recipients, base, _client)) {
     //end
     for (std::list<Client*>::iterator it_rec = recipients.begin();

--- a/src/IrcCommands/Commands/Privmsg.cpp
+++ b/src/IrcCommands/Commands/Privmsg.cpp
@@ -1,10 +1,9 @@
 #include <algorithm>  //std::find
-#include <iostream>
 #include <list>
 #include <map>
+#include <string>
 #include "../../Client/Client.hpp"
 #include "../../Server/Server.hpp"
-#include "../../includes/CONSTANTS.hpp"
 #include "../../includes/types.hpp"
 #include "../IrcCommands.hpp"
 

--- a/src/IrcCommands/IrcCommands.cpp
+++ b/src/IrcCommands/IrcCommands.cpp
@@ -37,9 +37,7 @@ IrcCommands::~IrcCommands() {}
  * (1) it checks which command is enquired by client
  * (2) it runs the commands for parsing
  *
- * TODO: handle case if command was not found
- *
- * @return it returns 1 if command was not found
+ * @return function returns 1 if command was not found
  */
 int IrcCommands::exec_command(Server& base, struct cmd_obj& cmd) {
   function to_execute;
@@ -53,3 +51,4 @@ int IrcCommands::exec_command(Server& base, struct cmd_obj& cmd) {
   (this->*to_execute)(base, cmd);
   return (0);
 }
+

--- a/src/IrcCommands/IrcCommands.hpp
+++ b/src/IrcCommands/IrcCommands.hpp
@@ -1,10 +1,8 @@
 #ifndef IRCCOMMANDS_HPP
 #define IRCCOMMANDS_HPP
 
-#include <iostream>
-#include <list>
 #include <map>
-#include <vector>
+#include <string>
 #include "../Client/Client.hpp"
 #include "../includes/types.hpp"
 
@@ -67,6 +65,8 @@ class IrcCommands {
   int exec_command(Server& base, struct cmd_obj& cmd);
   void send_message(Server& base, const cmd_obj& cmd, int numeric_msg_code,
                     Client* target, Channel* chan);
+  int get_all_recipients(std::list<Client*>& all_rec, Server& base,
+                         Client* sender);
 };
 
 #endif  //IRCCOMMANDS_HPP

--- a/src/IrcCommands/IrcCommandsUtils.cpp
+++ b/src/IrcCommands/IrcCommandsUtils.cpp
@@ -226,13 +226,23 @@ bool IrcCommands::client_register_check(Server& base, Client& to_check) {
 }
 
 /**
- * @brief function to get all membres the sender is connteced with via sharing the same
+ * @brief function to get all members the sender is connected with via sharing the same
  * channel membership
  *
  * @rturn returns 0 in case there is no connected member, otherwise 1
  */
 int IrcCommands::get_all_recipients(std::list<Client*>& all_rec, Server& base,
                                     Client* sender) {
+  std::map<Client*, bool> ret;
+  for (std::list<Channel>::iterator it_chan = base._channel_list.begin(); it_chan != base._channel_list.end(); it_chan++){
+	  if (it_chan->is_member(sender->get_nick())) {
+		  std::map<Client*, bool> chan_members = it_chan->get_members();
+            for (std::map<Client*, bool>::iterator it_chanmembers = chan_members.begin(); it_chanmembers != chan_members.end(); it_chanmembers++) {
+		    if (it_chanmembers->first->get_nick() != sender->get_nick())
+			    ret.insert(*it_chanmembers);
+
+			  }
+			  }
   if (sender->get_channels().empty())
     return (0);
   std::map<std::string, bool> _channel_list = sender->get_channels();

--- a/src/IrcCommands/IrcCommandsUtils.cpp
+++ b/src/IrcCommands/IrcCommandsUtils.cpp
@@ -10,8 +10,6 @@
 /**
  * @brief function to return the reply message of replymessagecode (rpl)
  *
- * TODO
- * (1) add all required rpl messages according to rpl_code
  */
 std::string IrcCommands::get_rpl(Server& base, const cmd_obj& cmd,
                                  enum RPL_MSG rpl, Channel* chan) {
@@ -38,28 +36,42 @@ std::string IrcCommands::get_rpl(Server& base, const cmd_obj& cmd,
       if (chan)
         return (chan->get_name() + " Modes: [" + chan->get_modes_string() +
                 "]");
+      else
+        return (": Error on channel configs");
     case RPL_CREATIONTIME:
       if (chan)
         return (chan->get_name() + " is created on " +
                 chan->get_creation_time());
+      else
+        return (": Error on channel configs");
     case RPL_NOTOPIC:
       if (chan)
         return (chan->get_name() + " :No topic is set");
+      else
+        return (": Error on channel configs");
     case RPL_TOPIC:
       if (chan)
         return (chan->get_name() + " topic: " + chan->get_topic());
+      else
+        return (": Error on channel configs");
     case RPL_TOPICWHOTIME:
       if (chan)
         return (chan->get_name() + " topic is set by " + chan->get_topic_who() +
                 " on " + chan->get_topic_time());
+      else
+        return (": Error on channel configs");
     case RPL_INVITING:
       return ("invites " + cmd.parameters[0] + " to " + cmd.parameters[1]);
     case RPL_NAMREPLY:
       if (chan)
         return (chan->get_name() + " " + chan->get_nicks_string());
+      else
+        return (": Error on channel configs");
     case RPL_ENDOFNAMES:
       if (chan)
         return (chan->get_name() + " :End of /NAMES list");
+      else
+        return (": Error on channel configs");
     case RPL_YOUREOPER:
       return (":You are now an IRC operator");
     default:
@@ -71,7 +83,6 @@ std::string IrcCommands::get_rpl(Server& base, const cmd_obj& cmd,
  * @brief function to return the error message of errorcode (err)
  *
  * TODO
- * (1) add all required error messages to corresponding error codes
  * (2) maybe remove paramter base if not required
  */
 std::string IrcCommands::get_error(Server& base, const cmd_obj& cmd,
@@ -114,12 +125,18 @@ std::string IrcCommands::get_error(Server& base, const cmd_obj& cmd,
     case ERR_USERNOTINCHANNEL:
       if (chan)
         return ("<nick> " + chan->get_name() + " :They aren't on that channel");
+      else
+        return (": Error on channel configs");
     case ERR_NOTONCHANNEL:
       if (chan)
         return (chan->get_name() + " :You're not on that channel");
+      else
+        return (" :You're not on that channel");
     case ERR_USERONCHANNEL:
       if (chan)
         return ("<nick> " + chan->get_name() + " :is already on channel");
+      else
+        return (": Error on channel configs");
     case ERR_NOTREGISTERED:
       return (" :You have not registered");
     case ERR_NEEDMOREPARAMS:
@@ -131,17 +148,25 @@ std::string IrcCommands::get_error(Server& base, const cmd_obj& cmd,
     case ERR_CHANNELISFULL:
       if (chan)
         return (chan->get_name() + " :Cannot join channel (+l)");
+      else
+        return (" :Cannot join channel (+l)");
     case ERR_INVITEONLYCHAN:
       if (chan)
         return (chan->get_name() + " :Cannot join channel (+i)");
+      else
+        return (" :Cannot join channel (+i)");
     case ERR_BADCHANNELKEY:
       if (chan)
         return (chan->get_name() + " :Cannot join channel (+k)");
+      else
+        return (" :Cannot join channel (+k)");
     case ERR_NOPRIVILEGES:
       return (" :Permission Denied- You're not an IRC operator");
     case ERR_CHANOPRIVSNEEDED:
       if (chan)
         return (chan->get_name() + " :You're not channel operator");
+      else
+        return (" :You're not channel operator");
     default:
       return (out);
   }

--- a/src/IrcCommands/IrcCommandsUtils.cpp
+++ b/src/IrcCommands/IrcCommandsUtils.cpp
@@ -1,6 +1,8 @@
 #include <iomanip>  // For std::setw and std::setfill
 #include <iostream>
+#include <map>
 #include <sstream>
+#include "../Channel/Channel.hpp"
 #include "../Client/Client.hpp"
 #include "../Server/Server.hpp"
 #include "../includes/CONSTANTS.hpp"
@@ -222,3 +224,40 @@ bool IrcCommands::client_register_check(Server& base, Client& to_check) {
   else
     return (0);
 }
+
+/**
+ * @brief function to get all membres the sender is connteced with via sharing the same
+ * channel membership
+ *
+ * @rturn returns 0 in case there is no connected member, otherwise 1
+ */
+int IrcCommands::get_all_recipients(std::list<Client*>& all_rec, Server& base,
+                                    Client* sender) {
+  if (sender->get_channels().empty())
+    return (0);
+  std::map<std::string, bool> _channel_list = sender->get_channels();
+  for (std::map<std::string, bool>::iterator it_chan_name =
+           _channel_list.begin();
+       it_chan_name != _channel_list.end(); it_chan_name++) {
+    if (base.get_channel_list().empty())
+      return (0);
+    std::list<Channel>::iterator it_chan_all = base.get_channel_list().begin();
+    for (; it_chan_all != base.get_channel_list().end(); it_chan_all++) {
+      if (it_chan_name->first == it_chan_all->get_name()) {
+        if (it_chan_all->get_members().empty())
+          return (0);
+        for (std::map<Client*, bool>::iterator it_chan_members =
+                 it_chan_all->get_members().begin();
+             it_chan_members != it_chan_all->get_members().end();
+             it_chan_members++) {
+          all_rec.push_back(it_chan_members->first);
+        }
+      }
+    }
+  }
+  if (all_rec.empty())
+    return (0);
+  else
+    return (1);
+}
+

--- a/src/IrcCommands/IrcCommandsUtils.cpp
+++ b/src/IrcCommands/IrcCommandsUtils.cpp
@@ -229,45 +229,34 @@ bool IrcCommands::client_register_check(Server& base, Client& to_check) {
  * @brief function to get all members the sender is connected with via sharing the same
  * channel membership
  *
- * @rturn returns 0 in case there is no connected member, otherwise 1
+ * TODO:
+ * (1) think about maybe using the std::map to write in all recipients (all_rec) instead of std::list
+ *
+ * @return returns 0 in case there is no connected member, otherwise 1
  */
 int IrcCommands::get_all_recipients(std::list<Client*>& all_rec, Server& base,
                                     Client* sender) {
   std::map<Client*, bool> ret;
-  for (std::list<Channel>::iterator it_chan = base._channel_list.begin(); it_chan != base._channel_list.end(); it_chan++){
-	  if (it_chan->is_member(sender->get_nick())) {
-		  std::map<Client*, bool> chan_members = it_chan->get_members();
-            for (std::map<Client*, bool>::iterator it_chanmembers = chan_members.begin(); it_chanmembers != chan_members.end(); it_chanmembers++) {
-		    if (it_chanmembers->first->get_nick() != sender->get_nick())
-			    ret.insert(*it_chanmembers);
-
-			  }
-			  }
-  if (sender->get_channels().empty())
-    return (0);
-  std::map<std::string, bool> _channel_list = sender->get_channels();
-  for (std::map<std::string, bool>::iterator it_chan_name =
-           _channel_list.begin();
-       it_chan_name != _channel_list.end(); it_chan_name++) {
-    if (base.get_channel_list().empty())
-      return (0);
-    std::list<Channel>::iterator it_chan_all = base.get_channel_list().begin();
-    for (; it_chan_all != base.get_channel_list().end(); it_chan_all++) {
-      if (it_chan_name->first == it_chan_all->get_name()) {
-        if (it_chan_all->get_members().empty())
-          return (0);
-        for (std::map<Client*, bool>::iterator it_chan_members =
-                 it_chan_all->get_members().begin();
-             it_chan_members != it_chan_all->get_members().end();
-             it_chan_members++) {
-          all_rec.push_back(it_chan_members->first);
-        }
+  for (std::list<Channel>::iterator it_chan = base._channel_list.begin();
+       it_chan != base._channel_list.end(); it_chan++) {
+    if (it_chan->is_member(sender->get_nick())) {
+      std::map<Client*, bool> chan_members = it_chan->get_members();
+      for (std::map<Client*, bool>::iterator it_chanmembers =
+               chan_members.begin();
+           it_chanmembers != chan_members.end(); it_chanmembers++) {
+        if (it_chanmembers->first->get_nick() != sender->get_nick())
+          ret.insert(*it_chanmembers);
       }
     }
+    if (ret.empty())
+      return (0);
+    else {
+      std::map<Client*, bool>::iterator it_members = ret.begin();
+      for (; it_members != ret.end(); it_members++) {
+        all_rec.push_back(it_members->first);
+      }
+      return (1);
+    }
   }
-  if (all_rec.empty())
-    return (0);
-  else
-    return (1);
 }
 

--- a/src/Parser/Parser.cpp
+++ b/src/Parser/Parser.cpp
@@ -6,13 +6,13 @@
 
 namespace Parsing {
   /**
- * @brief breaks down incomming string into cmd and params
+ * @brief breaks down incoming string into cmd and params
  * (1 --> commented out for testing reasons) it checks if message ends with CR-LF, if not it returns an individual message
  *     as there is no official one: input line to long (max size of input according to recv-buf is 8750 bytes)
  * (2) it tokenizes the string
- * (3) it checks for max size of message (if correclty terminated with CR-LF)
+ * (3) it checks for max size of message (if correctly terminated with CR-LF)
  * (4) it splits the tags and add them into com_obj.tags, if there are tags
- * (5) it checks if there is a prefix and adds it to com_onj.prefix
+ * (5) it checks if there is a prefix and adds it to com_obj.prefix
  * (6) it validates commands and does first error handling, if command does not exist
  * (7) it add paramters to com_obj_parameters
  * (8) it returns an error if size of parameters > 15: no error code provided by protocol, must clients return
@@ -27,7 +27,7 @@ namespace Parsing {
    colon character (':', 0x3b) (sic!), without gap between colon and prefix
  * (3) devide tokens into command and parameters
  *      - up to 15 parameters
- * (4) consider syntax rules of irc-protocoll
+ * (4) consider syntax rules of irc-protocol
  *      - The prefix, command, and all parameters are separated by one (or more) ASCII space character(s)
  *      - TAB is considered to be a non-white-space (therefore getline was used to parse the inputbuff)
  *      - NUL is not allowed within messages: how to check it?

--- a/src/Server/Server.cpp
+++ b/src/Server/Server.cpp
@@ -15,8 +15,11 @@
 #include "../IrcCommands/IrcCommands.hpp"
 #include "../debug.hpp"
 #include "../includes/CONSTANTS.hpp"
-#include "../includes/types.hpp"
 
+/**
+ * @brief socket for IRC-Server gets created in constructor
+ * IRC-Server is only able to read from IP4-addresses
+ */
 Server::Server(int port, std::string& pw)
     : _network_name("MUMs_network"),
       _server_name("MUMs_server"),

--- a/src/Server/Server.cpp
+++ b/src/Server/Server.cpp
@@ -18,7 +18,7 @@
 
 /**
  * @brief socket for IRC-Server gets created in constructor
- * IRC-Server is only able to read from IP4-addresses
+ * IRC-Server is only able to read from IPv4-addresses
  */
 Server::Server(int port, std::string& pw)
     : _network_name("MUMs_network"),

--- a/src/Server/Server.hpp
+++ b/src/Server/Server.hpp
@@ -1,8 +1,8 @@
 #include <netinet/in.h>  //for socket, bind, listen, accept
 #include <sys/socket.h>  //sockaddr_in
 #include <unistd.h>
-#include <iostream>
 #include <list>
+#include <string>
 #include <vector>
 #include "../Channel/Channel.hpp"
 #include "../Client/Client.hpp"
@@ -37,8 +37,6 @@ class Server {
   int handle_new_client();
   int handle_pollin(struct pollfd& poll_fd);
   int handle_pollout(struct pollfd& poll_fd);
-  void set_pollevent(int fd, int event);
-  void remove_pollevent(int fd, int event);
   void remove_client(int fd);
 
  public:
@@ -51,6 +49,9 @@ class Server {
   // Getters
   std::list<Channel>& get_channel_list();
   Client* find_client_by_fd(int fd);
+  // Setters
+  void set_pollevent(int fd, int event);
+  void remove_pollevent(int fd, int event);
 
   // function to activate the IRC-Server (run the server-loop)
   int init();

--- a/src/Server/ServerUtils.cpp
+++ b/src/Server/ServerUtils.cpp
@@ -2,7 +2,6 @@
 #include <iomanip>  // For std::setw and std::setfill
 #include <iostream>
 #include <sstream>  // for std::ostringstream
-#include "../debug.hpp"
 #include "../includes/types.hpp"
 
 /**
@@ -26,7 +25,7 @@ std::string get_current_date_time() {
  * @brief function to debug the result of the input parsing
  */
 void debug_parsed_cmds(cmd_obj& cmd_body) {
-
+#ifdef DEBUG
   std::cout << "CMD_BDY: " << std::endl;
   if (cmd_body.error)
     std::cout << "ERR: " << cmd_body.error << std::endl;
@@ -43,4 +42,6 @@ void debug_parsed_cmds(cmd_obj& cmd_body) {
       std::cout << *it << std::endl;
     }
   }
+#endif
+  (void)cmd_body;
 }

--- a/src/Server/ServerUtils.cpp
+++ b/src/Server/ServerUtils.cpp
@@ -42,6 +42,7 @@ void debug_parsed_cmds(cmd_obj& cmd_body) {
       std::cout << *it << std::endl;
     }
   }
-#endif
+#else
   (void)cmd_body;
+#endif
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,15 +14,8 @@
 #include <csignal>  //signal
 #include <cstdlib>
 #include <iostream>
-#include <sstream>  //for std::stringstream
 #include "Server/Server.hpp"
 #include "Utils/Utils.hpp"
-#include "debug.hpp"
-#include "includes/CONSTANTS.hpp"
-
-// TODO:
-// AF_INET == IPv4 | SOCK_STREAM = two-way connection-based byte streams |
-// protocl number (if several)
 
 Server* g_server;
 


### PR DESCRIPTION
I created an error handling if input is bigger than 512bytes.
- It returns an error message on server-stdout in debug-mode
- it sends an error message ERR_INPUTTOOLONG to sender